### PR TITLE
Update date range in README to 2010-2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Extraction Plugin FILETIME in Registry
 
-The plugin parses registry values with 8 byte BIN values that decode to a date between 2010 and 2022
+The plugin parses registry values with 8 byte BIN values that decode to a date between 2010 and 2026
 
 ## Licensing
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Extend the documented registry date decoding range from 2010–2022 to 2010–2026